### PR TITLE
Added multiple paths in CHECKSD_OVERRIDE

### DIFF
--- a/config.py
+++ b/config.py
@@ -222,8 +222,8 @@ def _checksd_path(directory):
     checks_override_env_split = checks_override_env.split(':')
     path_override=[]
     for checks_override_env_individual_path in checks_override_env_split:
-      if checks_override_env_individual_path and os.path.exists(checks_override_env_individual_path):
-        path_override.append(checks_override_env_individual_path)
+        if checks_override_env_individual_path and os.path.exists(checks_override_env_individual_path):
+            path_override.append(checks_override_env_individual_path)
     if path_override:
         return path_override
 
@@ -1021,8 +1021,8 @@ def get_checks_places(osname, agentConfig):
 
     # agent-bundled integrations
     if checksd_path:
-      for checksd_path_individual in checksd_path:
-        places.append(lambda name: (os.path.join(checksd_path_individual, '%s.py' % name), None))
+        for checksd_path_individual in checksd_path:
+            places.append(lambda name: (os.path.join(checksd_path_individual, '%s.py' % name), None))
     return places
 
 

--- a/config.py
+++ b/config.py
@@ -218,8 +218,13 @@ def _confd_path(directory):
 
 
 def _checksd_path(directory):
-    path_override = os.environ.get('CHECKSD_OVERRIDE')
-    if path_override and os.path.exists(path_override):
+    checks_override_env = os.environ.get('CHECKSD_OVERRIDE')
+    checks_override_env_split = checks_override_env.split(':')
+    path_override=[]
+    for checks_override_env_individual_path in checks_override_env_split:
+      if checks_override_env_individual_path and os.path.exists(checks_override_env_individual_path):
+        path_override.append(checks_override_env_individual_path)
+    if path_override:
         return path_override
 
     # this is deprecated in testing on versions after SDK (5.12.0)
@@ -1016,7 +1021,8 @@ def get_checks_places(osname, agentConfig):
 
     # agent-bundled integrations
     if checksd_path:
-        places.append(lambda name: (os.path.join(checksd_path, '%s.py' % name), None))
+      for checksd_path_individual in checksd_path:
+        places.append(lambda name: (os.path.join(checksd_path_individual, '%s.py' % name), None))
     return places
 
 

--- a/config.py
+++ b/config.py
@@ -220,7 +220,7 @@ def _confd_path(directory):
 def _checksd_path(directory):
     checks_override_env = os.environ.get('CHECKSD_OVERRIDE')
     checks_override_env_split = checks_override_env.split(':')
-    path_override=[]
+    path_override = []
     for checks_override_env_individual_path in checks_override_env_split:
         if checks_override_env_individual_path and os.path.exists(checks_override_env_individual_path):
             path_override.append(checks_override_env_individual_path)


### PR DESCRIPTION
Added multiple paths in CHECKSD_OVERRIDE (issue #3758)

*Note: Please remember to review the Datadog [Contribution Guidelines](https://github.com/DataDog/dd-agent/blob/master/CONTRIBUTING.md)
if you have not yet done so.*

### What does this PR do?

Adds the capability to supply multiple path values via CHECKSD_OVERRIDE env variable. The individual path values are assumed to be separated by ':' as the delimiter.

### Motivation

Reduce the uncertainty in where to place my custom checks. 

### Testing Guidelines

An overview on [testing](https://github.com/DataDog/dd-agent/blob/master/tests/README.md)
is available in our contribution guidelines.

### Additional Notes

Addresses issue #3758: https://github.com/DataDog/dd-agent/issues/3758
